### PR TITLE
strip leading v in semver tag names

### DIFF
--- a/actions/release-version/action.yml
+++ b/actions/release-version/action.yml
@@ -39,7 +39,7 @@ runs:
           const latestPublishedTime = new Date(latestRelease.data.published_at);
 
           // extract major, minor and patch numbers from the latest release tag
-          const [major, minor, patch] = tagName.split(".").map((x) => parseInt(x));
+          const [major, minor, patch] = tagName.replace(/^v/, "").split(".").map((x) => parseInt(x));
 
           console.log('latestTag', tagName)
 

--- a/actions/release-version/release-version.js
+++ b/actions/release-version/release-version.js
@@ -22,7 +22,7 @@ module.exports = async (github, context) => {
     const latestPublishedTime = new Date(latestRelease.data.published_at);
 
     // extract major, minor and patch numbers from the latest release tag
-    const [major, minor, patch] = tagName.split(".").map((x) => parseInt(x));
+    const [major, minor, patch] = tagName.replace(/^v/, "").split(".").map((x) => parseInt(x));
 
     console.log('latestTag', tagName)
 


### PR DESCRIPTION
## Description

I thought node's parseInt function handled this already but it doesnt on the version the action uses 
![image](https://user-images.githubusercontent.com/123459940/233260021-ec6a6d0c-a2f5-4c3b-b874-4e03ece4beaf.png)

## Linked Issues

- none

[GitHub Issue Linking Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Checklist

- [x] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [x] I have linked an issue from this repository using the **Development** option
- [x] I have performed a self-review of my own code
- [x] I have checked for redundant or commented out code
- [x] I have commented my code where I can't make it self-documenting
- [x] I have made corresponding changes to the documentation
- [x] I have added any appropriate tests
