### PR TITLE
perf(ci): optimize CI workflows with Blacksmith runners

### DIFF
--- a/.github/workflows/ci-require-labels.yml
+++ b/.github/workflows/ci-require-labels.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   require-labels:
     if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       status: ${{ steps.require-labels.outputs.status }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ permissions:
   pull-requests: read
 jobs:
   get-version:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     outputs:
       version: ${{ steps.get-version.outputs.version }}
     steps:
@@ -34,7 +34,7 @@ jobs:
           echo "SHORT_SHA: $(git rev-parse --short HEAD)" >> $GITHUB_STEP_SUMMARY
   release:
     if: ${{ needs.get-version.outputs.version != 'undefined' || (github.event_name == 'workflow_dispatch' && needs.get-version.outputs.version != 'undefined') }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     needs: [ get-version ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   yaml-lint:
     name: yaml-lint
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
               files=("${files[@]}" "$file")
             fi
           done
-          echo "::set-output name=files::${files[@]}"
+          echo "files=${files[@]}" >> $GITHUB_OUTPUT
 
       - name: Lint YAML files
         uses: karancode/yamllint-github-action@master
@@ -44,7 +44,7 @@ jobs:
   add-reviewers:
     if: "!contains( toJson(github), 'reviewers-set' )"
     needs: [yaml-lint]
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - name: add approvers
         uses: kentaro-m/auto-assign-action@v2.0.0


### PR DESCRIPTION
## Summary
- Migrated all CI workflows from `ubuntu-latest` to `blacksmith-4vcpu-ubuntu-2404` runners for improved performance
- Fixed deprecated `::set-output` command to use `GITHUB_OUTPUT` environment file in yaml-lint workflow

## Test plan
- [ ] Verify CI workflows run successfully on Blacksmith runners
- [ ] Confirm YAML lint step correctly outputs file list using GITHUB_OUTPUT

:robot: Generated with [Claude Code](https://claude.com/claude-code)